### PR TITLE
fix: display help correctly when no arguments are entered

### DIFF
--- a/docker/unchained.sh
+++ b/docker/unchained.sh
@@ -30,7 +30,7 @@ if ! docker compose version &>/dev/null; then
   exit 1
 fi
 
-if [ ! $1 == 'worker' ] && [ ! $1 == 'standalone' ]; then #&& [ ! $1 == 'remote' ] && [ ! $1 == 'lite' ] || [ -z $2 ]; then
+if [ ! $1 == 'worker' ] && [ ! $1 == 'standalone' ] || [ -z $1 ] || [ -z $2 ] ; then #&& [ ! $1 == 'remote' ] && [ ! $1 == 'lite' ] || [ -z $2 ]; then
   usage
   exit 1
 fi


### PR DESCRIPTION
This PR fixes the display of help messages when no arguments are passed to unchained.sh