### PR TITLE
Move the EVM RPC config under PoS in the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,49 @@
+## Next [WIP]
+
+- Move EVM RPC under PoS in configuration file
+
+## v0.14.0 (2025-01-07)
+
+- Implement the initial version of TEP-1: Unchained Plugins
+- Remove Gitmoji
+- Replace Commitizen with Lefthook
+- Add support for MongoDB
+- Add initial support for generic dataframes
+- Remove GraphQL support for queries
+- Replace Ent with Gorm
+
 ## v0.13.0 (2024-08-27)
 
 ### ✨ Features
 
 - add optional tls support
-- **func-config**: add config struct for registering functions >>> ⏰ 3h
-- **rpc**: refactor rpc service to accept unix socket >>> ⏰ 6h
-- **rpc**: add comments and re arrange codes >>> ⏰ 6h
-- **rpc-runtime**: add some runtime and refactor rpc service >>> ⏰ 6h
-- **handlers**: refactoring rpc handlers >>> ⏰ 4h
+- **func-config**: add config struct for registering functions
+- **rpc**: refactor rpc service to accept unix socket
+- **rpc**: add comments and re arrange codes
+- **rpc-runtime**: add some runtime and refactor rpc service
+- **handlers**: refactoring rpc handlers
 - **bls-test**: add unittest for bls and move bls sign to identity …
-- **bls-test**: add unittest for bls and move bls sign to identity method >>> ⏰ 1.5h
+- **bls-test**: add unittest for bls and move bls sign to identity method
 - add the new schnorr based pos contract
 - **identity**: add flag to get permission to write to secret file,…
-- **identity**: add flag to get permission to write to secret file, to prevent losing keys. and some refactor >>> ⏰ 3h
-- **identity**: merge and add unit test for identity >>> ⏰ 1h
+- **identity**: add flag to get permission to write to secret file, to prevent losing keys. and some refactor
+- **identity**: merge and add unit test for identity
 
 ### 🐛🚑️ Fixes
 
-- **concept**: remove unneccery file >>> ⏰ 5m
+- **concept**: remove unneccery file
 - fix rpc issues
 - small bug fixes
 - small bug fixes with rpc
 - filter out unavailable workers
-- **lint**: fix linters >>> ⏰ 5m
-- **eth-rpc**: fix problem of race condition for client list >>> ⏰ 1h
-- **eth-rpc**: rename isExist to isFound >>> ⏰ 2m
-- **eth-rpc**: fix problem of race condition for client list >>> ⏰ 1h
-- **linters**: do linter fixes >>> ⏰ 2m
-- **identity**: rename export signer function name >>> ⏰ 2m
-- **identity**: rename export signer function name >>> ⏰ 2m
-- **evmlog**: fix mutex problem >>> ⏰ 30m
+- **lint**: fix linters
+- **eth-rpc**: fix problem of race condition for client list
+- **eth-rpc**: rename isExist to isFound
+- **eth-rpc**: fix problem of race condition for client list
+- **linters**: do linter fixes
+- **identity**: rename export signer function name
+- **identity**: rename export signer function name
+- **evmlog**: fix mutex problem
 
 ### fix
 
@@ -42,7 +56,7 @@
 
 ### 🎨🏗️ Style & Architecture
 
-- **linter**: fix linters problems >>> ⏰ 3h
+- **linter**: fix linters problems
 - fix lint
 
 ### 🔐🚧📈✏️ 💩👽️🍻💬🥚🌱🚩🥅🩺 Others
@@ -57,9 +71,9 @@
 
 ### ✨ Features
 
-- **services**: add some tests to project >>> ⏰ 3h
-- **pubsub**: ability to send messages based on channels and sub-channel subscribe >>> ⏰ 6h
-- **pubsub**: add internal pubsub and lots of refactor >>> ⏰ 2d
+- **services**: add some tests to project
+- **pubsub**: ability to send messages based on channels and sub-channel subscribe
+- **pubsub**: add internal pubsub and lots of refactor
 - record consensus info on boolean records
 - refactor consensus to save all signatures in db
 - add slashing mechanism
@@ -68,27 +82,27 @@
 ### 🐛🚑️ Fixes
 
 - fix identity key generation
-- **flags**: make config flag unrequired >>> ⏰ 2m
-- **flags**: make config flag unrequired >>> ⏰ 2m
-- **attestation**: delete unused tests temprorary >>> ⏰ 2m
-- **connection**: fix the problem of reconnecting to the broker >>> ⏰ 2h
-- **linters**: fix linters >>> ⏰ 2m
-- **models**: fix problem of deserializing sia >>> ⏰ 2h
-- **badge**: move badger to services and add unit tests >>> ⏰ 30m
-- **linters**: solve linters problems >>> ⏰ 1h
-- **linters-services**: add a new linter and fix dup in services >>> ⏰ 30m
-- **crypto**: fix linters about comments >>> ⏰ 2m
-- **crypto**: fix unused assining in evm init >>> ⏰ 10m
-- **quickstart**: fix wrong address in the text >>> ⏰ 2m
-- **bls**: fix paths on bls >>> ⏰ 2m
-- **bls**: fix import paths of bls package >>> ⏰ 2m
+- **flags**: make config flag unrequired
+- **flags**: make config flag unrequired
+- **attestation**: delete unused tests temprorary
+- **connection**: fix the problem of reconnecting to the broker
+- **linters**: fix linters
+- **models**: fix problem of deserializing sia
+- **badge**: move badger to services and add unit tests
+- **linters**: solve linters problems
+- **linters-services**: add a new linter and fix dup in services
+- **crypto**: fix linters about comments
+- **crypto**: fix unused assining in evm init
+- **quickstart**: fix wrong address in the text
+- **bls**: fix paths on bls
+- **bls**: fix import paths of bls package
 
 ### ♻️ Refactorings
 
-- **ctx**: implement ctx passing through project >>> ⏰ 2h
-- **services**: capsulate services using interfaces >>> ⏰ 1h
+- **ctx**: implement ctx passing through project
+- **services**: capsulate services using interfaces
 - fix debounce and pre-hook issues
-- **crypto**: move etherum to crypto and refactor crypto to make a identity manage >>> ⏰ 2h
+- **crypto**: move etherum to crypto and refactor crypto to make a identity manage
 - refactor the eip712 module to repository pattern
 
 ### feat
@@ -136,7 +150,7 @@
 ### 📝💡 Documentation
 
 - **changelog**: add changelog
-- **crypto**: add some comments in crypto package >>> ⏰ 10m
+- **crypto**: add some comments in crypto package
 - add documentation for installing pre-commit hooks
 
 ### 🚨 Linting

--- a/conf.broker.yaml.template
+++ b/conf.broker.yaml.template
@@ -6,10 +6,9 @@ network:
   bind: 0.0.0.0:9123
   brokerUri: ws://localhost:9123
 
-rpc:
-  - name: arbitrumSepolia
-    nodes:
-      - https://sepolia-rollup.arbitrum.io/rpc
+pos:
+  rpc:
+    - https://sepolia-rollup.arbitrum.io/rpc
 
 mongo:
 dataframes:

--- a/conf.worker.yaml.template
+++ b/conf.worker.yaml.template
@@ -6,10 +6,9 @@ network:
   bind: 0.0.0.0:9123
   brokerUri: ws://localhost:9123
 
-rpc:
-  - name: arbitrumSepolia
-    nodes:
-      - https://sepolia-rollup.arbitrum.io/rpc
+pos:
+  rpc:
+    - https://sepolia-rollup.arbitrum.io/rpc
 
 mongo:
 dataframes:

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -19,8 +19,7 @@ type System struct {
 
 // RPC struct hold the rpc configuration of the application.
 type RPC struct {
-	Name  string   `yaml:"name"`
-	Nodes []string `yaml:"nodes"`
+	MaxConcurrency int `env:"RPC_MAX_CONCURRENCY" env-default:"10" yaml:"maxConcurrency"`
 }
 
 // Plugins struct hold the plugins configurations of the application.
@@ -33,9 +32,9 @@ type Plugin struct {
 
 // ProofOfStake struct hold the proof of stake contract's configurations.
 type ProofOfStake struct {
-	Chain   string `env:"POS_CHAIN"   env-default:"arbitrumSepolia"                            yaml:"chain"`
-	Address string `env:"POS_ADDRESS" env-default:"0x965e364987356785b7E89e2Fe7B70f5E5107332d" yaml:"address"`
-	Base    int64  `env:"POS_BASE"    env-default:"1"                                          yaml:"base"`
+	RPC     []string `env:"POS_RPC"     env-default:"https://sepolia-rollup.arbitrum.io/rpc"     yaml:"rpc"`
+	Address string   `env:"POS_ADDRESS" env-default:"0x965e364987356785b7E89e2Fe7B70f5E5107332d" yaml:"address"`
+	Base    int64    `env:"POS_BASE"    env-default:"1"                                          yaml:"base"`
 }
 
 // Network struct hold the network configuration of the application.

--- a/internal/crypto/ethereum/rpc_mock.go
+++ b/internal/crypto/ethereum/rpc_mock.go
@@ -15,21 +15,21 @@ type mockRPC struct {
 	backend *backends.SimulatedBackend
 }
 
-func (m mockRPC) GetClient(_ string) *ethclient.Client {
+func (m mockRPC) GetClient() *ethclient.Client {
 	// TODO implement me
 	panic("implement me")
 }
 
-func (m mockRPC) RefreshRPC(_ string) {}
+func (m mockRPC) RefreshRPC() {}
 
-func (m mockRPC) GetNewStakingContract(_ string, address string, _ bool) (*contracts.ProofOfStake, error) {
+func (m mockRPC) GetNewStakingContract(address string, _ bool) (*contracts.ProofOfStake, error) {
 	return contracts.NewProofOfStake(
 		common.HexToAddress(address),
 		m.backend,
 	)
 }
 
-func (m mockRPC) GetBlockNumber(_ context.Context, _ string) (uint64, error) {
+func (m mockRPC) GetBlockNumber(_ context.Context) (uint64, error) {
 	var blockNumber uint64 = 1000
 	return blockNumber, nil
 }

--- a/internal/service/pos/pos.go
+++ b/internal/service/pos/pos.go
@@ -81,7 +81,7 @@ func (s *service) GetVotingPower(address [20]byte, block *big.Int) (*big.Int, er
 }
 
 func (s *service) GetVotingPowerOfEvm(ctx context.Context, evmAddress string) (*big.Int, error) {
-	block, err := s.ethRPC.GetBlockNumber(ctx, config.App.ProofOfStake.Chain)
+	block, err := s.ethRPC.GetBlockNumber(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (s *service) GetSchnorrSigners(ctx context.Context) ([]common.Address, erro
 
 func (s *service) GetVotingPowerOfPublicKey(ctx context.Context, pkBytes [96]byte) (*big.Int, error) {
 	_, addrHex := address.CalculateHex(pkBytes[:])
-	block, err := s.ethRPC.GetBlockNumber(ctx, config.App.ProofOfStake.Chain)
+	block, err := s.ethRPC.GetBlockNumber(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,6 @@ func New(ethRPC ethereum.RPC) Service {
 	var err error
 
 	s.posContract, err = s.ethRPC.GetNewStakingContract(
-		config.App.ProofOfStake.Chain,
 		config.App.ProofOfStake.Address,
 		false,
 	)


### PR DESCRIPTION
This PR moves the EVM RPC config to PoS in the config file, freeing the RPC config scope for Unchained RPC-related configs. Adds a `MaxConcurrency` config option [unused/WIP] for the Unchained RPC to bootstrap the new scope.